### PR TITLE
corrected wrong link

### DIFF
--- a/src/network/protocol/messages/verack.zig
+++ b/src/network/protocol/messages/verack.zig
@@ -11,7 +11,7 @@ const CompactSizeUint = @import("bitcoin-primitives").types.CompatSizeUint;
 
 /// VerackMessage represents the "verack" message
 ///
-/// https://developer.bitcoin.org/reference/p2p_networking.html#version
+/// https://developer.bitcoin.org/reference/p2p_networking.html#verack
 pub const VerackMessage = struct {
     // verack message do not contain any payload, thus there is no field
 
@@ -42,7 +42,6 @@ pub const VerackMessage = struct {
         _ = self;
         return 0;
     }
-
 };
 
 // TESTS

--- a/src/network/wire/lib.zig
+++ b/src/network/wire/lib.zig
@@ -49,7 +49,7 @@ pub fn sendMessage(allocator: std.mem.Allocator, w: anytype, protocol_version: i
     defer allocator.free(payload);
     const checksum = computePayloadChecksum(payload);
 
-    // I believe it's safe. No payload will be longer than u32.MAX
+    // No payload will be longer than u32.MAX
     const payload_len: u32 = @intCast(payload.len);
 
     try w.writeAll(&network_id);
@@ -76,10 +76,10 @@ pub fn receiveMessage(allocator: std.mem.Allocator, r: anytype) !protocol.messag
     const checksum = try r.readBytesNoEof(4);
 
     // Read payload
-    const message: protocol.messages.Message = if (std.mem.eql(u8, &command, protocol.messages.VersionMessage.name())) 
-        protocol.messages.Message{ .Version = try protocol.messages.VersionMessage.deserializeReader(allocator, r)}
+    const message: protocol.messages.Message = if (std.mem.eql(u8, &command, protocol.messages.VersionMessage.name()))
+        protocol.messages.Message{ .Version = try protocol.messages.VersionMessage.deserializeReader(allocator, r) }
     else if (std.mem.eql(u8, &command, protocol.messages.VerackMessage.name()))
-        protocol.messages.Message{ .Verack = try protocol.messages.VerackMessage.deserializeReader(allocator, r)}
+        protocol.messages.Message{ .Verack = try protocol.messages.VerackMessage.deserializeReader(allocator, r) }
     else
         return error.InvalidCommand;
     errdefer message.deinit(allocator);


### PR DESCRIPTION
Before we merge this PR, I would like to discuss this comment:
``src/network/wire/lib.zig``
```zig
    // I believe it's safe. No payload will be longer than u32.MAX
    const payload_len: u32 = @intCast(payload.len);
```

As stated in the bitcoin documentation, "The current maximum number of bytes ([“MAX_SIZE”](https://github.com/bitcoin/bitcoin/blob/60abd463ac2eaa8bc1d616d8c07880dc53d97211/src/serialize.h#L23)) allowed in the payload by Bitcoin Core is 32 MiB—messages with a payload size larger than this will be dropped or rejected."

So, I removed the "I believe" part, as ``32 * 1024 * 1024 < u32::MAX``

To actually enforce the limit, we could do something like this maybe:
```zig
const MAX_PAYLOAD_SIZE: u32 = 32 * 1024 * 1024

const payload_len: u32 = @intCast(payload.len);
if (payload_len > MAX_PAYLOAD_SIZE) {
    return someerror
}
```
Is it worth opening an issue for ?